### PR TITLE
Fix compilation errors, warning, add all vehicles to cmake

### DIFF
--- a/AirLib/include/vehicles/fixedwing/firmwares/mavlink/MavLinkFixedWingApi.hpp
+++ b/AirLib/include/vehicles/fixedwing/firmwares/mavlink/MavLinkFixedWingApi.hpp
@@ -237,13 +237,13 @@ public: //methods
         updateState();
         return VectorMath::toQuaternion(current_state_.attitude.pitch, current_state_.attitude.roll, current_state_.attitude.yaw);
     }
- 
+
     virtual LandedState getLandedState() const override
     {
         updateState();
         return current_state_.controls.landed ? LandedState::Landed : LandedState::Flying;
     }
-	
+
     virtual real_T getActuation(unsigned int control_index) const override
     {
         if (!is_simulation_mode_)
@@ -326,7 +326,7 @@ public: //methods
         return waitForZ(timeout_sec, z, getDistanceAccuracy());
     }
 
-	//TODO: Update for a fixedwing landing, maintain RoD to touchdown point then autoflare etc. 
+	//TODO: Update for a fixedwing landing, maintain RoD to touchdown point then autoflare etc.
     virtual bool land(float timeout_sec) override
     {
         SingleCall lock(this);
@@ -493,7 +493,7 @@ protected: //methods
     virtual void commandRollPitchYawHold(float roll, float pitch, float yaw, float tla) override
     {
         checkValidVehicle();
-        mav_vehicle_->moveByAttitude(roll, pitch, 0, 0, 0, 0, tla); 
+        mav_vehicle_->moveByAttitude(roll, pitch, 0, 0, 0, 0, tla);
     }
 
 	// Not sure if this makes sense should I define a climb speed Vy and then set the aircraft to that if it does not match? setting thrust alone will not work!
@@ -510,8 +510,8 @@ protected: //methods
         float TLA = 0.10f + tla_controller_.control(-state.local_est.pos.z);
         mav_vehicle_->moveByAttitude(roll, pitch, yaw, 0, 0, 0, TLA);
     }
-	
-	
+
+
     virtual void commandAngleRates(float roll_rate, float pitch_rate, float yaw_rate, float tla) override
     {
         checkValidVehicle();
@@ -1226,10 +1226,10 @@ private: //methods
                 control_surfaces_[1] = HilControlsMessage.pitch_elevator;
                 control_surfaces_[2] = HilControlsMessage.yaw_rudder;
                 control_surfaces_[3] = HilControlsMessage.throttle;
-                control_surfaces_[4] = HilControlsMessage.aux1;
-                control_surfaces_[5] = HilControlsMessage.aux2;
-                control_surfaces_[6] = HilControlsMessage.aux3;
-                control_surfaces_[7] = HilControlsMessage.aux4;
+                // control_surfaces_[4] = HilControlsMessage.aux1;
+                // control_surfaces_[5] = HilControlsMessage.aux2;
+                // control_surfaces_[6] = HilControlsMessage.aux3;
+                // control_surfaces_[7] = HilControlsMessage.aux4;
 
                 normalizeControls();
                 received_actuator_controls_ = true;
@@ -1330,7 +1330,7 @@ private: //methods
         hil_sensor.ygyro = gyro.y();
         hil_sensor.zgyro = gyro.z();
 
-        hil_sensor.fields_updated |= 0b111000; // Set gyro bit fields 
+        hil_sensor.fields_updated |= 0b111000; // Set gyro bit fields
 
         hil_sensor.xmag = mag.x();
         hil_sensor.ymag = mag.y();

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingApiBase.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingApiBase.cpp
@@ -404,9 +404,9 @@ bool FixedWingApiBase::moveToPosition(float x, float y, float z, float velocity,
             Vector3r vel_body = VectorMath::transformToBodyFrame(vel_word, starting_quaternion, true);
 
             //find yaw as per terrain and remote setting
-            /*YawMode adj_yaw_mode(yaw_mode.is_rate, yaw_mode.yaw_or_rate);
-            adj_yaw_mode.yaw_or_rate += rc_data.yaw * 100.0f / kMaxRCValue;
-            adjustYaw(vel_body, drivetrain, adj_yaw_mode);*/ /*
+            // YawMode adj_yaw_mode(yaw_mode.is_rate, yaw_mode.yaw_or_rate);
+            // adj_yaw_mode.yaw_or_rate += rc_data.yaw * 100.0f / kMaxRCValue;
+            // adjustYaw(vel_body, drivetrain, adj_yaw_mode);
 
             //execute command
             try {
@@ -671,7 +671,7 @@ void FixedWingApiBase::moveToPathPosition(const Vector3r& dest, float velocity, 
     /*if (std::abs(cur.z() - dest.z()) <= getDistanceAccuracy()) //for paths in XY plan current code leaves z untouched, so we can compare with strict equality
         moveByVelocityZInternal(velocity_vect.x(), velocity_vect.y(), dest.z(), yaw_mode);
     else*/
-	
+
     moveByVelocityInternal(velocity_vect.x(), velocity_vect.y(), velocity_vect.z());
 }
 

--- a/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
+++ b/AirLib/src/vehicles/fixedwing/api/FixedWingRpcLibClient.cpp
@@ -101,7 +101,9 @@ FixedWingRpcLibClient* FixedWingRpcLibClient::moveByVelocityAsync(float vx, floa
 
 FixedWingRpcLibClient* FixedWingRpcLibClient::moveOnPathAsync(const vector<Vector3r>& path, float velocity, float timeout_sec, float lookahead, float adaptive_lookahead, const std::string& vehicle_name)
 {
-    pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveOnPathAsync", path, velocity, timeout_sec, lookahead, adaptive_lookahead, vehicle_name);
+    vector<FixedWingRpcLibAdapators::Vector3r> conv_path;
+    FixedWingRpcLibAdapators::from(path, conv_path);
+    pimpl_->last_future = static_cast<rpc::client*>(getClient())->async_call("moveOnPathAsync", conv_path, velocity, timeout_sec, lookahead, adaptive_lookahead, vehicle_name);
     return this;
 }
 

--- a/cmake/AirLib/CMakeLists.txt
+++ b/cmake/AirLib/CMakeLists.txt
@@ -18,10 +18,7 @@ file(GLOB_RECURSE ${PROJECT_NAME}_sources
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/api/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/common/common_utils/*.cpp
   ${AIRSIM_ROOT}/${PROJECT_NAME}/src/safety/*.cpp
-  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/car/api/*.cpp
-  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/*.cpp
-  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/multirotor/api/*.cpp
-  # ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/*.cpp
+  ${AIRSIM_ROOT}/${PROJECT_NAME}/src/vehicles/*.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC ${${PROJECT_NAME}_sources})


### PR DESCRIPTION
The RPC error was due to the fact that it doesn't know how to pack the Vector3r object, need to convert it into the struct defined in RpcLibAdaptorsBase and then pass it

There are still lots of undefined references errors, due to some function declarations not being commented out (implementations are commented out), and many are still used in FixedWingApiBase.cpp