### PR TITLE
Change back to old parameters, fix crash at startup

### DIFF
--- a/AirLib/include/vehicles/fixedwing/Airplane.hpp
+++ b/AirLib/include/vehicles/fixedwing/Airplane.hpp
@@ -96,7 +96,7 @@ namespace msr
 
 		private: // methods
 
-			virtual void setAoA()
+			void setAoA()
 			{
 				aoa_->aero_axis = VectorMath::rotateVector(kinematics_->getState().twist.angular, kinematics_->getState().pose.orientation, true);
 				aoa_->alpha = aoa_->aero_axis(0);
@@ -114,7 +114,7 @@ namespace msr
 				air_density_ratio_ = environment_->getState().air_density / air_density_sea_level_; // Sigma ratio
 			}
 
-			virtual void createControls()
+			void createControls()
 			{
 				aileron_deflection_ = controls_.at(0).getOutput().control_deflection;
 				elevator_deflection_ = controls_.at(1).getOutput().control_deflection;
@@ -122,12 +122,12 @@ namespace msr
 				tla_deflection_ = controls_.at(3).getOutput().control_deflection;
 			}
 
-			virtual void createPropulsionForces(const PropulsionDerivatives& derivatives, Output& output)
+			void createPropulsionForces(const PropulsionDerivatives& derivatives, Output& output)
 			{
 				output.thrust = derivatives.thrust_tla_coefficient;
 			}
 
-			virtual void createAeroForces(const LinearAeroDerivatives& derivatives, const Dimensions& dimensions, const Kinematics* kinematics, Output& output)
+			void createAeroForces(const LinearAeroDerivatives& derivatives, const Dimensions& dimensions, const Kinematics* kinematics, Output& output)
 			{
 				createControls();
 				const real_T airspeed = setAirspeed();

--- a/AirLib/include/vehicles/fixedwing/ControlSurface.hpp
+++ b/AirLib/include/vehicles/fixedwing/ControlSurface.hpp
@@ -82,7 +82,7 @@ namespace msr
 		private: // methods
 
 			//calculates all the forces
-			virtual void setOutput(Output& output, const FirstOrderFilter<real_T>& control_signal_filter)
+			void setOutput(Output& output, const FirstOrderFilter<real_T>& control_signal_filter)
 			{
 				output.control_signal_input = control_signal_filter_.getInput();
 				output.control_signal_filtered = control_signal_filter_.getOutput();

--- a/AirLib/include/vehicles/fixedwing/FixedWingParams.hpp
+++ b/AirLib/include/vehicles/fixedwing/FixedWingParams.hpp
@@ -41,8 +41,8 @@ namespace msr
 				/*parameters set with defaults*/
 				real_T restitution = 0.55f; // needed for FixedWingPawnSimApi.cpp API creation
 				real_T friction = 0.5f; // needed for FixedWingPawnSimApi.cpp API creation
-				uint control_count = 4; // number of control variables (elevator, aileron, rudder, TLA)
-				uint airplane_count = 1; // number of aircraft (Should not normally be more than 1)
+				uint control_count = 3; // number of control variables (elevator, aileron, rudder, TLA)
+				uint airplane_count = 0; // number of aircraft (Should not normally be more than 1)
 			};
 
 		protected:

--- a/AirLib/include/vehicles/fixedwing/FixedWingPhysicsBody.hpp
+++ b/AirLib/include/vehicles/fixedwing/FixedWingPhysicsBody.hpp
@@ -24,7 +24,7 @@ namespace msr
 				: params_(params), vehicle_api_(vehicle_api)
 			{
 				initialize(kinematics, environment);
-				printf("Hello Physics!");
+				Utils::log("Hello Physics!");
 			}
 			
 			//*** Start: UpdatableState implementation ***//
@@ -99,6 +99,7 @@ namespace msr
 			}
 			virtual PhysicsBodyVertex& getWrenchVertex(uint index)  override
 			{
+				Utils::log("getWrenchVertex called");
 				return airplane_;
 			}
 			virtual const PhysicsBodyVertex& getWrenchVertex(uint index) const override

--- a/AirLib/include/vehicles/multirotor/RotorActuator.hpp
+++ b/AirLib/include/vehicles/multirotor/RotorActuator.hpp
@@ -13,7 +13,7 @@
 #include "physics/PhysicsBodyVertex.hpp"
 #include "RotorParams.hpp"
 
-#include "Engine/Engine.h"
+// #include "Engine/Engine.h"
 
 namespace msr { namespace airlib {
 
@@ -114,8 +114,8 @@ protected:
         //forces and torques are proportional to air density: http://physics.stackexchange.com/a/32013/14061
         wrench.force = normal * output_.thrust * air_density_ratio_;
         wrench.torque = normal * output_.torque_scaler * air_density_ratio_; //TODO: try using filtered control here
-        FString DEBUG_MSG = FString::Printf(TEXT("Forces are being Called!"));
-        GEngine->AddOnScreenDebugMessage(2, 3000.0f, FColor::Blue, DEBUG_MSG);
+        // FString DEBUG_MSG = FString::Printf(TEXT("Forces are being Called!"));
+        // GEngine->AddOnScreenDebugMessage(2, 3000.0f, FColor::Blue, DEBUG_MSG);
     }
 
 private: //methods


### PR DESCRIPTION
Plus some cleanup

Saw the param change in the diff for the branch, reversing that fixed the `invalid vector subscript` error. Haven't tested with AP though

Also changed a line to `Utils::log`, that can be used anywhere in AirLib, no need to use the Engine one, the statement will come in debug log.
